### PR TITLE
[Hotfix] Pin GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: go test ./... -v
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
This PR pins the version of the GitHub Actions Goreleaser action used in the release workflow to a specific commit (`e435ccd777264be153ace6237001ef4d979d3a7a`), replacing the previously floating v6 tag. This change ensures consistent and predictable releases by locking the action version.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->